### PR TITLE
マンダリン語版の説明を修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@
 
 このカリキュラムは[クリエイティブ・コモンズ 表示 - 非営利 - 継承 4.0 国際 ライセンス](https://creativecommons.org/licenses/by-nc-sa/4.0/deed.ja)の下に提供されています。
 
-[![クリエイティブ・コモンズ・ライセンス](https://i.creativecommons.org/l/by-nc-sa/4.0/88x31.png)](https://creativecommons.org/licenses/by-nc-sa/4.0/deed.ja)  
+[![クリエイティブ・コモンズ・ライセンス](https://i.creativecommons.org/l/by-nc-sa/4.0/88x31.png)](https://creativecommons.org/licenses/by-nc-sa/4.0/deed.ja)
 
 ## Language Supports
 
-- 繁体字(zh_TW)
+- マンダリン語（繁体字：zh_TW）
   - https://github.com/5xruby/5xtraining （@jodeci 様ありがとうございます！）

--- a/README.md
+++ b/README.md
@@ -17,5 +17,5 @@
 
 ## Language Supports
 
-- マンダリン語（繁体字：zh_TW）
+- マンダリン（繁体字：zh_TW）
   - https://github.com/5xruby/5xtraining （@jodeci 様ありがとうございます！）


### PR DESCRIPTION
## 概要

繁体字はあくまで字体であり、説明としては言語名（マンダリン）を記載したほうが適切なのでそのように修正しました