### PR TITLE
繁体字の 体 を 體 に置き換え

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,5 +19,5 @@
 
 ## Language Supports
 
-- マンダリン（繁体字：zh_TW）
+- マンダリン（繁體字：zh_TW）
   - https://github.com/5xruby/5xtraining （@jodeci 様ありがとうございます！）


### PR DESCRIPTION
`繁體字` の方が台湾では正しい表記のようなので、修正しました