### PR TITLE
サンプルコードに用いているGithub Actionsのバージョンを見直す

### DIFF
--- a/github_actions/.github/workflows/lint.yml
+++ b/github_actions/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ jobs:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
       SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -22,7 +22,7 @@ jobs:
         run: bundle exec rubocop
       - name: Notify Slack when job failed
         if: ${{ failure() }}
-        uses: slackapi/slack-github-action@v1.18.0
+        uses: slackapi/slack-github-action@v1.26.0
         with:
           payload: |
             {

--- a/github_actions/.github/workflows/test.yml
+++ b/github_actions/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
       SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -42,7 +42,7 @@ jobs:
         run: bundle exec rspec
       - name: Notify Slack when job failed
         if: ${{ failure() }}
-        uses: slackapi/slack-github-action@v1.18.0
+        uses: slackapi/slack-github-action@v1.26.0
         with:
           payload: |
             {


### PR DESCRIPTION
## 何をしたか

github/workflows のサンプルコードに記載していたActionの新しいバージョンがリリースされていたので、
指定を変更する。
それぞれ以下のバージョンへ変更を行い、workflowが問題なく動作することを確認済み
`actions/checkout`→4系
`slackapi/slack-github-action`→ 1.26.0


https://github.com/actions/checkout/blob/main/CHANGELOG.md
https://github.com/slackapi/slack-github-action/releases