### PR TITLE
rubocopからのおすすめの扱いについて案内する

### DIFF
--- a/rubocop/README.md
+++ b/rubocop/README.md
@@ -9,3 +9,25 @@
 ご自分で設定をカスタマイズされる場合は、.rubocop.yml に記述します。
 .elcop.yml と .elcop-rspec.yml は、本研修カリキュラムの一部として更新される場合があります。
 必要に応じて新しいバージョンに置き換えてご利用ください。
+
+## RubocopのSuggestionについて
+研修を進めていくうちに`capybara`などのgemをインストールすることがあると思います。
+それぞれのgem専用に対応したcopがある場合、rubocop実行時に以下のようなメッセージでおすすめしてくれます。
+
+```
+Tip: Based on detected gems, the following RuboCop extension libraries might be helpful:
+  * rubocop-capybara (https://rubygems.org/gems/rubocop-capybara)
+  * rubocop-rspec_rails (https://rubygems.org/gems/rubocop-rspec_rails)
+
+You can opt out of this message by adding the following to your config (see https://docs.rubocop.org/rubocop/extensions.html#extension-suggestions for more options):
+  AllCops:
+    SuggestExtensions: false
+```
+
+ところがこのメッセージは、おすすめのcopを導入するまでずっと表示されてしまいます。本来の rubocop 実行結果に集中しづらくなるため、
+メッセージに書かれている通りに、`SuggestExtensions: false` を .rubocop.yml に追記しましょう。
+
+```yml
+  AllCops:
+    SuggestExtensions: false 
+```


### PR DESCRIPTION
gemをinstallするとrubocopから extensionをsuggestされることがある。
例）
```
Tip: Based on detected gems, the following RuboCop extension libraries might be helpful:
  * rubocop-capybara (https://rubygems.org/gems/rubocop-capybara)
  * rubocop-rspec_rails (https://rubygems.org/gems/rubocop-rspec_rails)

You can opt out of this message by adding the following to your config (see https://docs.rubocop.org/rubocop/extensions.html#extension-suggestions for more options):
  AllCops:
    SuggestExtensions: false
```
このSuggestionは対応するまでずっと表示されるので、なにか放置している感じがあったり、単純にrubocopの結果を見るのにじゃまになる。
よってこの研修を進める上では一旦おすすめ機能をoffにしてもらうようにする。