### PR TITLE
GitHub Actions のサンプルを使用すると `missing_text_or_fallback_or_attachments` が発生するので修正

### DIFF
--- a/github_actions/.github/workflows/test.yml
+++ b/github_actions/.github/workflows/test.yml
@@ -46,6 +46,6 @@ jobs:
         with:
           payload: |
             {
-              "url": "${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
+              "text": "テストが失敗しているよ！\n${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
             }
     timeout-minutes: 10


### PR DESCRIPTION
## やったこと

[github_actions/.github/workflows/test.yml](https://github.com/everyleaf/el-training/blob/063fdc08d29555a9c3891ffb395263826f35b045/github_actions/.github/workflows/test.yml) を参考に GitHub Actions を設定すると slack-github-action の実行時に `missing_text_or_fallback_or_attachments` のエラーが発生することがわかったため修正を行いました。

## 動作確認

* Incoming Webhook との連携を確認しました
* webhook url はダミーです

### Before（payload が url のみ）

```sh
curl -X POST \
  --location "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX" \
  -H "Content-Type: application/x-www-form-urlencoded" \
  -d 'payload={
        "url": "https://github.com/everyleaf/el-training"
      }'
missing_text_or_fallback_or_attachments%
```
`missing_text_or_fallback_or_attachments` エラーが返る
### After（payload が text のみ）

```sh
curl -X POST \
  --location "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX" \
  -H "Content-Type: application/x-www-form-urlencoded" \
  -d 'payload={
        "text": "テストが失敗しているよ！\nhttps://github.com/everyleaf/el-training"
      }'
ok%
```
`ok` が返る
<img width="315" alt="image" src="https://github.com/user-attachments/assets/afae947d-1c29-4145-a558-7ddd8526202a">

## 参考

* https://github.com/slackapi/slack-github-action
* https://api.slack.com/messaging/webhooks