### PR TITLE
slack-github-action のバージョンアップ (`v2.0.0`) に追従

### DIFF
--- a/github_actions/.github/workflows/lint.yml
+++ b/github_actions/.github/workflows/lint.yml
@@ -8,9 +8,6 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
-    env:
-      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-      SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
     steps:
       - uses: actions/checkout@v4
       - name: Set up Ruby
@@ -22,10 +19,12 @@ jobs:
         run: bundle exec rubocop
       - name: Notify Slack when job failed
         if: ${{ failure() }}
-        uses: slackapi/slack-github-action@v1.26.0
+        uses: slackapi/slack-github-action@v2.0.0
         with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
           payload: |
             {
-              "url": "${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
+              "text": "Rubocop lint job failed. Check the details here: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
             }
     timeout-minutes: 3

--- a/github_actions/.github/workflows/test.yml
+++ b/github_actions/.github/workflows/test.yml
@@ -25,8 +25,6 @@ jobs:
       PGUSER: postgres
       PGPASSWORD: password
       PGHOST: 127.0.0.1
-      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-      SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -42,10 +40,12 @@ jobs:
         run: bundle exec rspec
       - name: Notify Slack when job failed
         if: ${{ failure() }}
-        uses: slackapi/slack-github-action@v1.26.0
+        uses: slackapi/slack-github-action@v2.0.0
         with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
           payload: |
             {
-              "text": "テストが失敗しているよ！\n${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
+              "text": "Test job failed. Check the details here: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
             }
     timeout-minutes: 10


### PR DESCRIPTION
## 概要

slack-github-action の v2.0.0 がリリースされたので関連する設定ファイルも新バージョン対応にしたい

https://github.com/slackapi/slack-github-action/releases/tag/v2.0.0

## やったこと
* `v1.26.0` -> `v2.0.0` バージョンアップ
* [The webhook type must be specified for incoming webhooks](https://github.com/slackapi/slack-github-action/releases/tag/v2.0.0#the-webhook-type-must-be-specified-for-incoming-webhooks) 対応
* ついでにメッセージ文言修正