### PR TITLE
checkout/setup-node GitHub action のバージョンをv4に更新

### DIFF
--- a/.github/workflows/markdown_link_check.yml
+++ b/.github/workflows/markdown_link_check.yml
@@ -11,10 +11,10 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18
 


### PR DESCRIPTION
checkout/setup-node ともに新しいバージョンがリリースされていたためそれらを使用するように更新しました。

ref: https://github.com/jwetzell/setup-node/blob/8f152de45cc393bb48ce5d89d36b731f54556e65/README.md?plain=1#L86-L87